### PR TITLE
Fix relative meaning of coordinates

### DIFF
--- a/simulator-desktop/src/main/kotlin/com/landry/digital/logic/simulator/desktop/Main.kt
+++ b/simulator-desktop/src/main/kotlin/com/landry/digital/logic/simulator/desktop/Main.kt
@@ -47,7 +47,7 @@ fun uiMain() = singleWindowApplication(
         detectDragGestures { change, dragAmount ->
             change.consume()
 
-            simulatorComponent.onPointerDrag(dragAmount.x, dragAmount.y)
+            simulatorComponent.onPointerDrag(-dragAmount.x, -dragAmount.y)
         }
     }.clickable(interactionSource = remember {  MutableInteractionSource() }, indication = null) {
         simulatorComponent.onClick()

--- a/simulator-desktop/src/main/kotlin/com/landry/digital/logic/simulator/desktop/components/SimulatorComponent.kt
+++ b/simulator-desktop/src/main/kotlin/com/landry/digital/logic/simulator/desktop/components/SimulatorComponent.kt
@@ -37,6 +37,10 @@ class SimulatorComponent(context: ComponentContext): SimulatorUiLogic, Component
     override val state = MutableStateFlow(SimulatorState())
     private var currentGate: LogicGate? = null
     private var currentWire: WireUIState? = null
+
+    /**
+     * The current grid-space coordinate of the user's mouse
+     */
     private var currentCoordinate: CursorPosition? = null
     private val simulator = UISimulator()
 
@@ -115,7 +119,7 @@ class SimulatorComponent(context: ComponentContext): SimulatorUiLogic, Component
         val currentState = state.value
         val currentLayoutState = currentState.layoutState
         val rawPosition = event.changes.first().position
-        val position = rawPosition - Offset(currentLayoutState.currentX, currentLayoutState.currentY)
+        val position = rawPosition + Offset(currentLayoutState.currentX, currentLayoutState.currentY)
         val gridX = position.x / currentLayoutState.gridSizePx
         val gridY = position.y / currentLayoutState.gridSizePx
         currentCoordinate = CursorPosition(gridX, gridY)

--- a/simulator-ui/src/composeMain/kotlin/com/landry/digital/logic/simulator/ui/SimulatorLayout.kt
+++ b/simulator-ui/src/composeMain/kotlin/com/landry/digital/logic/simulator/ui/SimulatorLayout.kt
@@ -14,8 +14,18 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.landry.digital.engine.ui.UICircuit
 
-data class SimulatorLayoutState(val currentX: Float = 0.0f, val currentY: Float = 0.0f,
-                                val gridSize: Dp = 10.dp, val density: Float)
+data class SimulatorLayoutState(
+    /**
+     * The current grid-space x-coordinate of the left of the screen.
+     */
+    val currentX: Float = 0.0f,
+    /**
+     * The current grid-space y-coordinate of the top of the screen.
+     */
+    val currentY: Float = 0.0f,
+    val gridSize: Dp = 10.dp,
+    val density: Float
+)
 
 val SimulatorLayoutState.gridSizePx get() = gridSize.value * density
 
@@ -25,8 +35,8 @@ fun SimulatorLayout(modifier: Modifier = Modifier,
                         SimulatorLayoutState(density = 1f),
                     onScroll: (Float) -> Unit,
                     circuit: UICircuit) {
-    val gridOffsetX = layoutState.currentX % layoutState.gridSizePx
-    val gridOffsetY = layoutState.currentY % layoutState.gridSizePx
+    val gridOffsetX = -layoutState.currentX % layoutState.gridSizePx
+    val gridOffsetY = -layoutState.currentY % layoutState.gridSizePx
     Canvas(modifier.scrollable(
         orientation = Orientation.Vertical,
         state = rememberScrollableState { delta ->
@@ -38,11 +48,11 @@ fun SimulatorLayout(modifier: Modifier = Modifier,
     }
 
     for(gate in circuit.gates) {
-        gate.draw(layoutState.gridSize, layoutState.currentX.dp, layoutState.currentY.dp)
+        gate.draw(layoutState.gridSize, -layoutState.currentX.dp, -layoutState.currentY.dp)
     }
 
     for(wire in circuit.wires) {
-        wire.draw(layoutState.gridSize, layoutState.currentX.dp, layoutState.currentY.dp)
+        wire.draw(layoutState.gridSize, -layoutState.currentX.dp, -layoutState.currentY.dp)
     }
 }
 


### PR DESCRIPTION
Originally, `currentLayoutState.currentX` and `currentLayoutState.currentX` unintentionally indicated where (0, 0) is relative to the screen. This PR inverts it to mean 'where the top left of the screen is relative to (0, 0)', which is what was originally intended.